### PR TITLE
Fixed crash after individual model finished with warning

### DIFF
--- a/R/fn_elastic_net.R
+++ b/R/fn_elastic_net.R
@@ -64,8 +64,12 @@ fn_elasticnet <- function(x, y, alpha.step = 0.1){
         })
     }
 
-    models.cvm <- unlist(lapply(models, function(model){
-        min(model$cvm)
+    models.cvm <- unlist(lapply(models, function(model) {
+      if (!is.na(model)) {
+        return(min(model$cvm))
+      } else {
+        return(Inf)
+      }
     }))
 
     #return model with smallest residual sum of squares


### PR DESCRIPTION
This should prevent the crash reported by catching glmnet calculations that finished with warnings:
"#2023-10-04 17:12:22 ERROR::e: $ operator is invalid for atomic vectors
#2023-10-04 17:12:22 ERROR::e: model$cvm”